### PR TITLE
Add infrastucture for testing type inference.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - run: pip install pytest
+      - run: pip install pytest typing-extensions
       - run: pytest . --junitxml=junit/test_py${{ matrix.python-version }}_on_${{ matrix.os }}.xml
       - run: python -O once_test.py
       - run: python -OO once_test.py
@@ -53,5 +53,5 @@ jobs:
           python-version: 3.13
           cache: pip
       - run: |
-          pip install mypy
+          pip install mypy typing-extensions
           mypy .

--- a/once_test.py
+++ b/once_test.py
@@ -14,6 +14,8 @@ import unittest
 import uuid
 import weakref
 
+# import typing_extensions
+
 import once
 
 
@@ -679,13 +681,15 @@ class TestOnce(unittest.TestCase):
         gc.collect()
         self.assertIsNone(ephemeral_ref())
 
-    def test_function_signature_preserved(self):
+    def test_function_signature_preserved(self) -> None:
         def type_annotated_fn(arg: float) -> int:
             """Very descriptive docstring."""
             del arg
             return 1
 
         decorated_function = once.once(type_annotated_fn)
+        # TODO(shreyas): This currently fails when running mypy once_test.py
+        # typing_extensions.assert_type(decorated_function(1.0), int)
         original_sig = inspect.signature(type_annotated_fn)
         decorated_sig = inspect.signature(decorated_function)
         self.assertIs(original_sig.parameters["arg"].annotation, float)


### PR DESCRIPTION
We include a sample test which can demonstrate the failure, which is
currently commented-out. Uncommenting would give:
```
~ mypy once_test.py
once_test.py:691: error: Expression is of type "Any", not "int"  [assert-type]
Found 1 error in 1 file (checked 1 source file)
```
