### PR TITLE
Increase parallel test timeout.

### DIFF
--- a/once_test.py
+++ b/once_test.py
@@ -44,7 +44,7 @@ def parallel_map(
     # would be collections.abc.Iterable[tuple] | None on py >= 3.10
     call_args=None,
     n_threads: int = _N_WORKERS,
-    timeout: float = 20.0,
+    timeout: float = 60.0,
 ) -> list:
     """Run a function multiple times in parallel.
 

--- a/once_test.py
+++ b/once_test.py
@@ -44,7 +44,7 @@ def parallel_map(
     # would be collections.abc.Iterable[tuple] | None on py >= 3.10
     call_args=None,
     n_threads: int = _N_WORKERS,
-    timeout: float = 10.0,
+    timeout: float = 20.0,
 ) -> list:
     """Run a function multiple times in parallel.
 


### PR DESCRIPTION
This should make tests less flaky on slower platforms.