### PR TITLE
Preserve type hints for wrapped functions

### DIFF
--- a/once/__init__.py
+++ b/once/__init__.py
@@ -247,7 +247,7 @@ def _wrap(
             wrapped.reset = reset  # type: ignore
 
     functools.update_wrapper(wrapped, func)
-    return wrapped
+    return wrapped  # type: ignore
 
 
 def _once_factory(is_async: bool, per_thread: bool, allow_reset: bool) -> _ONCE_FACTORY_TYPE:

--- a/once_test.py
+++ b/once_test.py
@@ -14,7 +14,7 @@ import unittest
 import uuid
 import weakref
 
-# import typing_extensions
+import typing_extensions
 
 import once
 
@@ -688,8 +688,7 @@ class TestOnce(unittest.TestCase):
             return 1
 
         decorated_function = once.once(type_annotated_fn)
-        # TODO(shreyas): This currently fails when running mypy once_test.py
-        # typing_extensions.assert_type(decorated_function(1.0), int)
+        typing_extensions.assert_type(decorated_function(1.0), int)
         original_sig = inspect.signature(type_annotated_fn)
         decorated_sig = inspect.signature(decorated_function)
         self.assertIs(original_sig.parameters["arg"].annotation, float)


### PR DESCRIPTION
Makes use of `typing.ParamSpec` and `typing.TypeVar` to parametrize input/output types for decorated functions, allowing us to preserve the types of decorated functions.
We accomplish this on `once_per_class` and `once_per_instance` by making the classes themselves generic. 

Since we require `typing.ParamSpec` which was introduced in `python3.10`, this PR also drops support for `python3.8` and `python3.9` in favour of remaining without dependencies.

Replaces #31.